### PR TITLE
Security: Dependabot findings.

### DIFF
--- a/.github/workflows/build.from.developer.branch.deploy.to.dev.yml
+++ b/.github/workflows/build.from.developer.branch.deploy.to.dev.yml
@@ -54,7 +54,7 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ github.event.inputs.choice }}
 
@@ -64,7 +64,7 @@ jobs:
           echo "TAG=latest ${GITHUB_SHA::12}" | tee -a $GITHUB_ENV
 
       - name: Login to Docker Hub
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           registry: ${{ vars.DOCKER_ARTIFACTORY_REPO }}
           username: ${{ vars.DOCKER_ARTIFACTORY_USERNAME }}

--- a/.github/workflows/build.from.main.branch.deploy.to.dev.yml
+++ b/.github/workflows/build.from.main.branch.deploy.to.dev.yml
@@ -42,7 +42,7 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Determine image tags
         if: env.TAG == ''
@@ -50,7 +50,7 @@ jobs:
           echo "TAG=latest ${GITHUB_SHA::12}" | tee -a $GITHUB_ENV
 
       - name: Login to Docker Hub
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           registry: ${{ vars.DOCKER_ARTIFACTORY_REPO }}
           username: ${{ vars.DOCKER_ARTIFACTORY_USERNAME }}

--- a/.github/workflows/build.from.release.branch.deploy.to.dev.yml
+++ b/.github/workflows/build.from.release.branch.deploy.to.dev.yml
@@ -48,7 +48,7 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: grad-release
 
@@ -58,7 +58,7 @@ jobs:
           echo "TAG=latest ${GITHUB_SHA::12}" | tee -a $GITHUB_ENV
 
       - name: Login to Docker Hub
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           registry: ${{ vars.DOCKER_ARTIFACTORY_REPO }}
           username: ${{ vars.DOCKER_ARTIFACTORY_USERNAME }}

--- a/.github/workflows/create_tag.yml
+++ b/.github/workflows/create_tag.yml
@@ -35,7 +35,7 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Create tag
         uses: actions/github-script@v5
@@ -54,7 +54,7 @@ jobs:
           oc: 4
 
         # https://github.com/redhat-actions/oc-login#readme
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Tag in OpenShift
         run: |
           set -eux

--- a/.github/workflows/deploy_prod.yml
+++ b/.github/workflows/deploy_prod.yml
@@ -36,7 +36,7 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Get latest tag
         uses: actions-ecosystem/action-get-latest-tag@v1

--- a/.github/workflows/deploy_test.yml
+++ b/.github/workflows/deploy_test.yml
@@ -36,7 +36,7 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Get latest tag
         uses: actions-ecosystem/action-get-latest-tag@v1

--- a/.github/workflows/on.pr.yml
+++ b/.github/workflows/on.pr.yml
@@ -17,12 +17,13 @@ jobs:
         working-directory: api
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
       - name: Set up JDK 18
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v4
         with:
+          distribution: 'corretto'
           java-version: 18
       - uses: actions/cache@v1
         with:
@@ -33,7 +34,7 @@ jobs:
       - name: Run unit tests
         run: mvn -f pom.xml clean package
       - name: Run Trivy vulnerability scanner in repo mode
-        uses: aquasecurity/trivy-action@0.2.5
+        uses: aquasecurity/trivy-action@0.29.0
         with:
           scan-type: 'fs'
           ignore-unfixed: true

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -57,9 +57,12 @@
         <maven.compiler.version>3.10.1</maven.compiler.version>
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
-        <org.mapstruct.version>1.5.2.Final</org.mapstruct.version>
+        <org.mapstruct.version>1.6.3</org.mapstruct.version>
         <junit>4.12</junit>
-        <log4j.version>2.18.0</log4j.version>
+        <log4j.version>2.24.3</log4j.version>
+        <jackson.version>2.18.2</jackson.version>
+        <batik.version>1.17</batik.version>
+        <docx4j.version>11.5.1</docx4j.version>
         <maven.test.skip>false</maven.test.skip>
         <!--jacoco.skip>true</jacoco.skip-->
         <start-class>ca.bc.gov.educ.grad.report.api.ReportApiApplication</start-class>
@@ -188,22 +191,6 @@
             <version>3.1.0</version>
         </dependency>
         <dependency>
-            <groupId>org.docx4j</groupId>
-            <artifactId>docx4j</artifactId>
-            <version>6.1.2</version>
-            <scope>runtime</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.slf4j</groupId>
-                    <artifactId>slf4j-log4j12</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>log4j</groupId>
-                    <artifactId>log4j</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
             <groupId>org.apache.poi</groupId>
             <artifactId>poi-ooxml</artifactId>
             <version>5.2.2</version>
@@ -212,7 +199,7 @@
         <dependency>
             <groupId>org.docx4j</groupId>
             <artifactId>docx4j-export-fo</artifactId>
-            <version>8.1.6</version>
+            <version>${docx4j.version}</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/xerces/xercesImpl -->
         <dependency>
@@ -224,7 +211,7 @@
         <dependency>
             <groupId>org.docx4j</groupId>
             <artifactId>docx4j-core</artifactId>
-            <version>8.0.0</version>
+            <version>${docx4j.version}</version>
         </dependency>
         <dependency>
             <groupId>org.junit.vintage</groupId>
@@ -245,13 +232,13 @@
         <dependency>
             <groupId>org.flywaydb</groupId>
             <artifactId>flyway-core</artifactId>
-            <version>8.5.13</version>
+            <version>11.2.0</version>
         </dependency>
         <!-- ORACLE database driver -->
         <dependency>
-            <groupId>com.oracle.jdbc</groupId>
-            <artifactId>ojdbc8</artifactId>
-            <version>12.2.0.1</version>
+            <groupId>com.oracle.database.jdbc</groupId>
+            <artifactId>ojdbc11</artifactId>
+            <version>23.6.0.24.10</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/commons-beanutils/commons-beanutils -->
         <dependency>
@@ -269,13 +256,13 @@
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
-            <version>2.7</version>
+            <version>2.18.0</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/org.apache.commons/commons-text -->
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-text</artifactId>
-            <version>1.9</version>
+            <version>1.10.0</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/org.apache.commons/commons-lang3 -->
         <dependency>
@@ -444,46 +431,46 @@
         <dependency>
             <groupId>com.fasterxml.jackson.dataformat</groupId>
             <artifactId>jackson-dataformat-xml</artifactId>
-            <version>2.13.3</version>
+            <version>${jackson.version}</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.dataformat</groupId>
             <artifactId>jackson-dataformat-yaml</artifactId>
-            <version>2.13.3</version>
+            <version>${jackson.version}</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/com.fasterxml.jackson.datatype/jackson-datatype-jdk8 -->
         <dependency>
             <groupId>com.fasterxml.jackson.datatype</groupId>
             <artifactId>jackson-datatype-jdk8</artifactId>
-            <version>2.13.3</version>
+            <version>${jackson.version}</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/com.fasterxml.jackson.datatype/jackson-datatype-jsr310 -->
         <dependency>
             <groupId>com.fasterxml.jackson.datatype</groupId>
             <artifactId>jackson-datatype-jsr310</artifactId>
-            <version>2.13.3</version>
+            <version>${jackson.version}</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/com.fasterxml.jackson.module/jackson-module-parameter-names -->
         <dependency>
             <groupId>com.fasterxml.jackson.module</groupId>
             <artifactId>jackson-module-parameter-names</artifactId>
-            <version>2.13.3</version>
+            <version>${jackson.version}</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/com.fasterxml.jackson.core/jackson-databind -->
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.13.3</version>
+            <version>${jackson.version}</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
-            <version>2.13.3</version>
+            <version>${jackson.version}</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
-            <version>2.13.3</version>
+            <version>${jackson.version}</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/org.javassist/javassist -->
         <dependency>
@@ -495,7 +482,7 @@
         <dependency>
             <groupId>joda-time</groupId>
             <artifactId>joda-time</artifactId>
-            <version>2.9.3</version>
+            <version>2.13.0</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/com.jcraft/jsch -->
         <dependency>
@@ -520,7 +507,7 @@
         <dependency>
             <groupId>org.reflections</groupId>
             <artifactId>reflections</artifactId>
-            <version>0.9.11</version>
+            <version>0.10.2</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/org.apache.velocity/velocity-engine-core -->
         <dependency>
@@ -532,7 +519,7 @@
         <dependency>
             <groupId>org.apache.xmlgraphics</groupId>
             <artifactId>batik-all</artifactId>
-            <version>1.14</version>
+            <version>${batik.version}</version>
             <type>pom</type>
         </dependency>
         <dependency>
@@ -619,97 +606,97 @@
         <dependency>
             <groupId>org.apache.xmlgraphics</groupId>
             <artifactId>batik-anim</artifactId>
-            <version>1.14</version>
+            <version>${batik.version}</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/org.apache.xmlgraphics/batik-awt-util -->
         <dependency>
             <groupId>org.apache.xmlgraphics</groupId>
             <artifactId>batik-awt-util</artifactId>
-            <version>1.14</version>
+            <version>${batik.version}</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/org.apache.xmlgraphics/batik-bridge -->
         <dependency>
             <groupId>org.apache.xmlgraphics</groupId>
             <artifactId>batik-bridge</artifactId>
-            <version>1.14</version>
+            <version>${batik.version}</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/org.apache.xmlgraphics/batik-codec -->
         <dependency>
             <groupId>org.apache.xmlgraphics</groupId>
             <artifactId>batik-codec</artifactId>
-            <version>1.14</version>
+            <version>${batik.version}</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/org.apache.xmlgraphics/batik-constants -->
         <dependency>
             <groupId>org.apache.xmlgraphics</groupId>
             <artifactId>batik-constants</artifactId>
-            <version>1.14</version>
+            <version>${batik.version}</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/org.apache.xmlgraphics/batik-css -->
         <dependency>
             <groupId>org.apache.xmlgraphics</groupId>
             <artifactId>batik-css</artifactId>
-            <version>1.14</version>
+            <version>${batik.version}</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/org.apache.xmlgraphics/batik-dom -->
         <dependency>
             <groupId>org.apache.xmlgraphics</groupId>
             <artifactId>batik-dom</artifactId>
-            <version>1.14</version>
+            <version>${batik.version}</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/org.apache.xmlgraphics/batik-gvt -->
         <dependency>
             <groupId>org.apache.xmlgraphics</groupId>
             <artifactId>batik-gvt</artifactId>
-            <version>1.14</version>
+            <version>${batik.version}</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/org.apache.xmlgraphics/batik-i18n -->
         <dependency>
             <groupId>org.apache.xmlgraphics</groupId>
             <artifactId>batik-i18n</artifactId>
-            <version>1.14</version>
+            <version>${batik.version}</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/org.apache.xmlgraphics/batik-parser -->
         <dependency>
             <groupId>org.apache.xmlgraphics</groupId>
             <artifactId>batik-parser</artifactId>
-            <version>1.14</version>
+            <version>${batik.version}</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/org.apache.xmlgraphics/batik-script -->
         <dependency>
             <groupId>org.apache.xmlgraphics</groupId>
             <artifactId>batik-script</artifactId>
-            <version>1.14</version>
+            <version>${batik.version}</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/org.apache.xmlgraphics/batik-svg-dom -->
         <dependency>
             <groupId>org.apache.xmlgraphics</groupId>
             <artifactId>batik-svg-dom</artifactId>
-            <version>1.14</version>
+            <version>${batik.version}</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/org.apache.xmlgraphics/batik-svggen -->
         <dependency>
             <groupId>org.apache.xmlgraphics</groupId>
             <artifactId>batik-svggen</artifactId>
-            <version>1.14</version>
+            <version>${batik.version}</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/org.apache.xmlgraphics/batik-transcoder -->
         <dependency>
             <groupId>org.apache.xmlgraphics</groupId>
             <artifactId>batik-transcoder</artifactId>
-            <version>1.14</version>
+            <version>${batik.version}</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/org.apache.xmlgraphics/batik-util -->
         <dependency>
             <groupId>org.apache.xmlgraphics</groupId>
             <artifactId>batik-util</artifactId>
-            <version>1.14</version>
+            <version>${batik.version}</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/org.apache.xmlgraphics/batik-xml -->
         <dependency>
             <groupId>org.apache.xmlgraphics</groupId>
             <artifactId>batik-xml</artifactId>
-            <version>1.14</version>
+            <version>${batik.version}</version>
         </dependency>
         <!--dependency>
             <groupId>org.testcontainers</groupId>


### PR DESCRIPTION

Change Details:

- Bump org.flywaydb:flyway-core from 8.5.13 to 11.2.0  
- Bump com.fasterxml.jackson.core:jackson-databind from 2.13.3 to 2.13.4.2  
- Bump org.apache.xmlgraphics:batik-script from 1.14 to 1.17  
- Bump org.apache.xmlgraphics:batik-bridge from 1.14 to 1.17  
- Bump joda-time:joda-time from 2.9.3 to 2.13.0  
- Bump commons-io:commons-io from 2.7 to 2.18.0  
- Bump org.docx4j:docx4j-core from 8.0.0 to 11.5.1  
- Bump actions/checkout from 2 to 4 
- Bump github/codeql-action from 2 to 3 
- Bump actions/setup-java from 1 to 4 
- Bump aquasecurity/trivy-action from 0.2.5 to 0.29.0 
- Bump docker/login-action from 2 to 3 
- Bump commons-text from 1.9 to 1.10.0  
- Bump reflections from 0.9.11 to 0.10.2  
- Bump org.apache.logging.log4j:log4j-to-slf4j from 2.18.0 to 2.24.3  
- Bump org.mapstruct.version from 1.5.2.Final to 1.6.3
- Upgrade ojdbc8 to ojdbc11